### PR TITLE
Adjust `<Nav />` Component to Use Correct Size for Titles

### DIFF
--- a/src/Nav/index.tsx
+++ b/src/Nav/index.tsx
@@ -110,7 +110,7 @@ const MultiSections = ({
                 direction="row"
                 alignItems="center"
                 padding="16px"
-                height="52px"
+                height="20px"
                 justifyContent={collapse ? "space-between" : "unset"}
               >
                 <Text


### PR DESCRIPTION
This pull request adjusts the `<Nav />` component to ensure that it uses the correct size for titles, so we reduce the size of the stack container for that title. 