### PR TITLE
 Move nav tokens from foundations to component

### DIFF
--- a/src/Nav/Tokens/tokens.ts
+++ b/src/Nav/Tokens/tokens.ts
@@ -1,0 +1,37 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  background: {
+    color: inube.palette.neutral.N10,
+  },
+  divider: {
+    color: inube.palette.neutral.N40,
+  },
+  title: {
+    appearance: "gray",
+  },
+  subtitle: {
+    appearance: {
+      regular: "gray",
+      expanded: "primary",
+    },
+    background: {
+      expanded: inube.palette.neutral.N30,
+    },
+  },
+  link: {
+    appearance: {
+      regular: "dark",
+      selected: "primary",
+    },
+    background: {
+      selected: inube.palette.neutral.N30,
+      hover: inube.palette.neutral.N30,
+    },
+  },
+  copyright: {
+    appearance: "gray",
+  },
+};
+
+export { tokens };

--- a/src/Nav/index.tsx
+++ b/src/Nav/index.tsx
@@ -3,7 +3,6 @@ import { MdLogout } from "react-icons/md";
 
 import { ITextAppearance, Text } from "@inubekit/text";
 import { Stack } from "@inubekit/stack";
-import { inube } from "@inubekit/foundations";
 
 import {
   StyledNav,
@@ -16,10 +15,10 @@ import {
 } from "./styles";
 import { NavLink } from "../NavLink";
 import { ILink, INavNavigation } from "./props";
-
 import { useContext, useEffect, useState } from "react";
 import { ThemeContext } from "styled-components";
 import { Icon } from "@inubekit/icon";
+import { tokens } from "./Tokens/tokens";
 
 interface INav {
   navigation: INavNavigation;
@@ -67,13 +66,13 @@ const MultiSections = ({
   collapse: boolean;
 }) => {
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { nav: typeof tokens };
   const navRegularTitleAppearance =
     (theme?.nav?.subtitle?.appearance?.regular as ITextAppearance) ||
-    inube.nav.subtitle.appearance.regular;
+    tokens.subtitle.appearance.regular;
   const navExpandedTitleAppearance =
     (theme?.nav?.subtitle?.appearance?.expanded as ITextAppearance) ||
-    inube.nav.subtitle.appearance.expanded;
+    tokens.subtitle.appearance.expanded;
 
   useEffect(() => {
     if (collapse && Object.keys(navigation.sections).length > 0) {
@@ -185,13 +184,13 @@ const Nav = (props: INav) => {
     footerLabel = `inube - ${year}`,
     footerLogo,
   } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { nav: typeof tokens };
   const navSubtitleAppearance =
     (theme?.nav?.subtitle?.appearance?.regular as ITextAppearance) ||
-    inube.nav.subtitle.appearance.regular;
+    tokens.subtitle.appearance.regular;
   const navCopyrightAppearance =
     (theme?.nav?.copyright?.appearance as ITextAppearance) ||
-    inube.nav.copyright.appearance;
+    tokens.copyright.appearance;
   return (
     <StyledNav>
       <Stack direction="column" justifyContent="space-between" height="100dvh">

--- a/src/Nav/styles.js
+++ b/src/Nav/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
 const SeparatorLine = styled.div`
@@ -8,7 +8,7 @@ const SeparatorLine = styled.div`
   height: 1px;
   padding: 0px;
   background-color: ${({ theme }) =>
-    theme?.nav?.divider?.color || inube.nav.divider.color};
+    theme?.nav?.divider?.color || tokens.divider.color};
 `;
 
 const StyledAnimatedWrapper = styled.div`
@@ -24,8 +24,8 @@ const StyledCollapseContainer = styled.div`
     background-color: ${({ theme, $collapse, $expanded }) =>
       $collapse && $expanded
         ? theme?.nav?.subtitle?.background?.expanded ||
-          inube.nav.subtitle.background.expanded
-        : theme?.nav?.background?.color || inube.nav.background.color};
+          tokens.subtitle.background.expanded
+        : theme?.nav?.background?.color || tokens.background.color};
   }
 `;
 
@@ -37,9 +37,9 @@ const StyledNav = styled.nav`
   width: 248px;
   box-sizing: border-box;
   background-color: ${({ theme }) =>
-    theme?.nav?.background?.color || inube.nav.background.color};
+    theme?.nav?.background?.color || tokens.background.color};
   border-right: 1px solid
-    ${({ theme }) => theme?.nav?.divider?.color || inube.nav.divider.color};
+    ${({ theme }) => theme?.nav?.divider?.color || tokens.divider.color};
 `;
 
 const StyledRotatingIcon = styled(MdKeyboardArrowDown)`

--- a/src/NavLink/index.tsx
+++ b/src/NavLink/index.tsx
@@ -6,7 +6,7 @@ import { Grid } from "@inubekit/grid";
 import { StyledLink, StyledNavList } from "./styles";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Nav/Tokens/tokens";
 
 interface INavLink {
   id: string;
@@ -29,14 +29,14 @@ const NavLink = (props: INavLink) => {
     onClick,
   } = props;
 
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { nav: typeof tokens };
 
   const selectedNavLinkAppearance =
     (theme?.nav?.link?.appearance?.selected as IIconAppearance) ||
-    inube.nav.link.appearance.selected;
+    tokens.link.appearance.selected;
   const regularNavLinkAppearance =
     (theme?.nav?.link?.appearance?.regular as IIconAppearance) ||
-    inube.nav.link.appearance.regular;
+    tokens.link.appearance.regular;
   return (
     <StyledNavList
       id={id}

--- a/src/NavLink/styles.js
+++ b/src/NavLink/styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-
-import { inube } from "@inubekit/foundations";
+import { TextTokens } from "@inubekit/text";
+import { tokens } from "../Nav/Tokens/tokens";
 
 const StyledNavList = styled.li`
   display: flex;
@@ -14,8 +14,8 @@ const StyledNavList = styled.li`
   border-left: ${({ appearance, disabled, theme }) => {
     if (appearance && !disabled) {
       return `5px solid ${
-        theme?.nav?.[appearance]?.content?.color?.regular ||
-        inube.text[appearance].content.color.regular
+        theme?.text?.[appearance]?.content?.color?.hover ||
+        TextTokens[appearance].content.color.hover
       }`;
     }
     return `5px solid transparent`;
@@ -24,13 +24,13 @@ const StyledNavList = styled.li`
     if (disabled) {
       return (
         theme?.nav?.link?.background?.selected ||
-        inube.nav.link.background.selected
+        tokens.link.background.selected
       );
     }
     if (selected && !disabled) {
       return (
         theme?.nav?.link?.background?.selected ||
-        inube.nav.link.background.selected
+        tokens.link.background.selected
       );
     }
   }};
@@ -40,7 +40,7 @@ const StyledNavList = styled.li`
     `
       &:hover {
         background-color: ${
-          theme?.nav?.link?.background?.hover || inube.nav.link.background.hover
+          theme?.nav?.link?.background?.hover || tokens.link.background.hover
         };     
       }
   `};


### PR DESCRIPTION
This PR relocates the nav tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring components are using the correct token paths. This refactor improves the organization, maintainability, and clarity of the codebase.