### PR TITLE
fix: add scroll-y behavior of nav

### DIFF
--- a/src/Nav/stories/Nav.WithLogo.stories.tsx
+++ b/src/Nav/stories/Nav.WithLogo.stories.tsx
@@ -22,7 +22,16 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <Story />
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "auto 1fr",
+            height: "100vh",
+            overflow: "hidden",
+          }}
+        >
+          <Story />
+        </div>
       </BrowserRouter>
     ),
   ],
@@ -109,7 +118,8 @@ WithFooterProps.args = {
     },
   ],
   collapse: true,
-  footerLogo: "https://i.imgur.com/YYrs6cF.png",
+  footerLogo:
+    "https://res.cloudinary.com/wfercanas/image/upload/v1729119253/linpar/selsa_jybzim.png",
 };
 
 export { WithFooterProps };

--- a/src/Nav/stories/Nav.stories.tsx
+++ b/src/Nav/stories/Nav.stories.tsx
@@ -22,7 +22,16 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <Story />
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "auto 1fr",
+            height: "100vh",
+            overflow: "hidden",
+          }}
+        >
+          <Story />
+        </div>
       </BrowserRouter>
     ),
   ],

--- a/src/Nav/styles.js
+++ b/src/Nav/styles.js
@@ -35,12 +35,16 @@ const StyledFooter = styled.footer`
 
 const StyledNav = styled.nav`
   width: 248px;
-  box-sizing: border-box;
   background-color: ${({ theme }) =>
     theme?.nav?.background?.color || tokens.background.color};
   border-right: 1px solid
     ${({ theme }) => theme?.nav?.divider?.color || tokens.divider.color};
   height: inherit;
+
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-gutter: auto;
+
   & > div > div > li {
     cursor: pointer;
   }


### PR DESCRIPTION
The StyledNav component didn't allow to scroll-y the nav when the amount of links forced the component to use a vertical space greater than 100vh. This change adds the overflow-x: scroll css property to allow this behavior and also styles the scrollbar so its width uses the `thin` variant of the browser.

The stories are also adjusted so that they reflect a more real scenario, where the Nav uses the whole viewport height (vh).